### PR TITLE
Mark MaskedTextFieldDelegate.listener as weak

### DIFF
--- a/Source/InputMask/InputMask/Classes/View/MaskedTextFieldDelegate.swift
+++ b/Source/InputMask/InputMask/Classes/View/MaskedTextFieldDelegate.swift
@@ -78,7 +78,7 @@ open class MaskedTextFieldDelegate: NSObject, UITextFieldDelegate {
         }
     }
     
-    open var listener: MaskedTextFieldDelegateListener?
+    open weak var listener: MaskedTextFieldDelegateListener?
     
     public init(format: String) {
         self._maskFormat = format


### PR DESCRIPTION
Seems like this is mostly used as a callback from a masked text field delegate back to the view controller that created it, but issue is that this strongly holds the view controller/listener in memory.

Noticed that in a project, setting this listener variable was preventing the view controller from being deallocated from memory.