### PR TITLE
Change offset calculation to fix a crash with a predictive typing.

### DIFF
--- a/Source/InputMask/InputMask/Classes/View/MaskedTextFieldDelegate.swift
+++ b/Source/InputMask/InputMask/Classes/View/MaskedTextFieldDelegate.swift
@@ -224,7 +224,7 @@ open class MaskedTextFieldDelegate: NSObject, UITextFieldDelegate {
         let updatedText: String = replaceCharacters(inText: field.text ?? "", range: range, withCharacters: text)
         let caretPosition: String.Index = updatedText.index(
             updatedText.startIndex,
-            offsetBy: field.cursorPosition + text.count
+            offsetBy: range.location + text.count
         )
         
         let mask: Mask = pickMask(


### PR DESCRIPTION
Fix for issue #60
https://github.com/RedMadRobot/input-mask-ios/issues/60