### PR TITLE
textFieldDidEndEditing don't called fix

### DIFF
--- a/Source/InputMask/InputMask/Classes/View/MaskedTextFieldDelegate.swift
+++ b/Source/InputMask/InputMask/Classes/View/MaskedTextFieldDelegate.swift
@@ -165,7 +165,11 @@ open class MaskedTextFieldDelegate: NSObject, UITextFieldDelegate {
     
     @available(iOS 10.0, *)
     open func textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason) {
-        listener?.textFieldDidEndEditing?(textField, reason: reason)
+        if listener?.textFieldDidEndEditing?(textField, reason: reason) != nil {
+            listener?.textFieldDidEndEditing?(textField, reason: reason)
+        } else {
+            listener?.textFieldDidEndEditing?(textField)
+        }
     }
     
     open func textField(


### PR DESCRIPTION
Implementation of this method `textFieldDidEndEditing(_ textField: UITextField, reason: UITextField.DidEndEditingReason)` cause `func textFieldDidEndEditing(_ textField: UITextField)` will not be called.