### PR TITLE
Fixed Package.swift for SPM usage.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,6 @@ let package = Package(
             name: "InputMask",
             dependencies: [],
             path: "Source/InputMask/InputMask",
-            exclude: ["Classes/View"],
             sources: ["Classes"]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ These folks rock:
 * Sergey [SergeyCHiP](https://github.com/SergeyCHiP) Germanovich
 * Luiz [LuizZak](https://github.com/LuizZak) Fernando
 * Ivan [vani](https://github.com/vani2) Vavilov
+* Diego [diegotl](https://github.com/diegotl) Trevisan
 
 # License
 


### PR DESCRIPTION
Package.swift was excluding sources inside `Classes/View` and preventing the project to implement `MaskedTextFieldDelegateListener`, etc.