### PR TITLE
Fix for UI issue with floating label of MDCTextInputControllerOutlined

### DIFF
--- a/Source/InputMask/InputMask/Classes/View/MaskedTextFieldDelegate.swift
+++ b/Source/InputMask/InputMask/Classes/View/MaskedTextFieldDelegate.swift
@@ -194,8 +194,10 @@ open class MaskedTextFieldDelegate: NSObject, UITextFieldDelegate {
     
     open func textFieldDidBeginEditing(_ textField: UITextField) {
         if autocompleteOnFocus && (textField.text ?? "").isEmpty {
-            let result: Mask.Result = put(text: "", into: textField, autocomplete: true)
-            notifyOnMaskedTextChangedListeners(forTextField: textField, result: result)
+            DispatchQueue.main.async {
+                let result: Mask.Result = put(text: "", into: textField, autocomplete: true)
+                notifyOnMaskedTextChangedListeners(forTextField: textField, result: result)
+            }
         }
         listener?.textFieldDidBeginEditing?(textField)
     }


### PR DESCRIPTION
I faced with annoying UI issue with `MDCTextInputControllerOutlined`.
In case of this type of Material Design textfield controller has  `MaskedTextFieldDelegate` with params `{ primaryMaskFormat = "+7-[000]-[000]-[0000]", autocompleteOnFocus = true}`, on first focus floating point doesn't display correctly.  
If `autocompleteOnFocus=false` or mask without leading chars (example `[000]-[000]-[0000]`), everything works fine.  
My suggestion, the issue related to method `put(...)`, it changes the textfield text in wrong moment.  
Later execution in `main.async{}` fixes everything.  

Please, consider the code review to put all same code patterns in `textFieldDidBeginEditing` and maybe `textViewDidBeginEditing` into `main.async{}` blocks.