### PR TITLE
Exclude Supporting Files folder during SPM installation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
             name: "InputMask",
             dependencies: [],
             path: "Source/InputMask/InputMask",
+            exclude: ["Supporting Files"],
             sources: ["Classes"]
         ),
         .testTarget(


### PR DESCRIPTION
Building the library from the current master branch is triggering a warning. 

<img width="1222" alt="Screenshot 2024-08-19 at 15 30 41" src="https://github.com/user-attachments/assets/0bc0e52c-0a15-40fe-aec0-e44b9cf6c1e0">

Since this file is required for Carthage support, it can be excluded from the SPM package.